### PR TITLE
Select textareas by name attribute

### DIFF
--- a/templates/forms/fields/tinymce/tinymce.html.twig
+++ b/templates/forms/fields/tinymce/tinymce.html.twig
@@ -24,7 +24,7 @@
 	</div>
 	<script>
 		tinymce.init({
-			selector: "textarea.tinymce",
+			selector: "textarea[name=\"{{ (scope ~ field.name)|fieldName }}\"]",
 			convert_urls: false,
 			document_base_url: "{{ (uri.rootUrl(true) ~ admin.page.rawRoute)|e("js") }}/",
 			language: "{{ url('user://data/tinymce-editor/js/' ~ version ~ '/langs/' ~ grav.user.language ~ '.js')|default(url('user://data/tinymce-editor/js/' ~ version ~ '/langs/' ~ grav.user.language ~ '_' ~ (grav.user.language|upper) ~ '.js')|default(url('plugins://tinymce-editor/js/' ~ version ~ '/langs/' ~ grav.user.language ~ '.js')|default(url('plugins://tinymce-editor/js/' ~ version ~ '/langs/' ~ grav.user.language ~ '_' ~ (grav.user.language|upper) ~ '.js'))))|split('/')|last|split('.')|first }}",


### PR DESCRIPTION
I changed the selector being used by TinyMCE from a class shared by all "tinymce" field textareas to the unique name of the textarea.  This seems to resolve #42 and also seems to provide better performance as TinyMCE is no longer trying to reinitialize all textareas on the page.